### PR TITLE
Fix: small bug fixes for new theme files discovered on client site

### DIFF
--- a/acf-json/group_65f20f758161e.json
+++ b/acf-json/group_65f20f758161e.json
@@ -1473,9 +1473,7 @@
                             "hide_label": "",
                             "hide_instructions": "",
                             "hide_required": "",
-                            "choices": {
-                                "": "Select",
-                            },
+                            "choices": {},
                             "default_value": false,
                             "return_format": "value",
                             "multiple": 0,

--- a/php/filters.php
+++ b/php/filters.php
@@ -1190,8 +1190,8 @@ function get_posts_with_data($s) {
 	$query = [
 		'post_type' => $s['post_type'],
 		'post_status' => 'publish',
-		'posts_per_page' => $s['pagination']['posts_per_page'],
-		'paged' => $s['pagination']['page'],
+		'posts_per_page' => $s['pagination']['show_all']  == 'n' ? $s['pagination']['posts_per_page'] : '-1',
+		'paged' => $s['pagination']['show_all']  == 'n' ? $s['pagination']['page'] : false,
 		'orderby' => []
 	];
 


### PR DESCRIPTION
Fixed trailing comma issue in acf json for the filter block's admin settings, and fixed some warnings caused by not accounting for pagination being disabled in the filter block