### PR TITLE
3.x mario

### DIFF
--- a/acf-json/group_659d2e0372278.json
+++ b/acf-json/group_659d2e0372278.json
@@ -80,6 +80,45 @@
                     "allow_custom": 0,
                     "search_placeholder": "",
                     "min": ""
+                },
+                {
+                    "key": "field_66799b371d5e9",
+                    "label": "Preset",
+                    "name": "preset",
+                    "aria-label": "",
+                    "type": "select",
+                    "instructions": "Select from the available settings for this block. Leave blank to use the default settings.",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "hide_field": "",
+                    "hide_label": "",
+                    "hide_instructions": "",
+                    "hide_required": "",
+                    "choices": {
+                        ": Select": ": Select"
+                    },
+                    "default_value": false,
+                    "return_format": "value",
+                    "multiple": 0,
+                    "max": "",
+                    "prepend": "",
+                    "append": "",
+                    "acfe_settings": "",
+                    "acfe_validate": "",
+                    "allow_null": 1,
+                    "instruction_placement": "tooltip",
+                    "acfe_permissions": "",
+                    "ui": 0,
+                    "ajax": 0,
+                    "placeholder": "",
+                    "allow_custom": 0,
+                    "search_placeholder": "",
+                    "min": ""
                 }
             ]
         }
@@ -110,5 +149,5 @@
     "acfe_permissions": "",
     "acfe_meta": "",
     "acfe_note": "",
-    "modified": 1718724372
+    "modified": 1719245914
 }

--- a/php/blocks.php
+++ b/php/blocks.php
@@ -682,7 +682,7 @@ if (get_theme_mod('feat_content_blocks', '1') === '1') {
 				'choice' => 'field_659d2fcdd2f8e'
 			],
 			[ // preset and preset_name fields
-				'user' => 'field_663d0ad50e7bb',
+				'user' => 'field_66799b371d5e9',
 				'choice' => 'field_659fd4dcc3449'
 			],
 


### PR DESCRIPTION
Slider Block only had styles, no preset for the user to use in the block when putting adding it to the editor. this adds the missing field.